### PR TITLE
Add Matlab snipper

### DIFF
--- a/lib/snippers/index.coffee
+++ b/lib/snippers/index.coffee
@@ -4,7 +4,8 @@ module.exports =
 class Snippers
 
   @snipperNames = [
-    'coffee'
+    'coffee',
+    'matlab'
   ]
 
   snippers: new Map

--- a/lib/snippers/matlab.coffee
+++ b/lib/snippers/matlab.coffee
@@ -1,0 +1,27 @@
+Snipper = require './snipper'
+
+module.exports =
+class MatlabSnipper extends Snipper
+
+  extensions: ['m']
+
+  generate: (tag) ->
+    return null if tag.kind isnt 'f'
+
+    argsString = ''
+    matches = tag.pattern.match(/\(([^\(\)]*)\)/)
+    argsString = matches[1].trim() if matches
+    snippetCount = 1
+    args = []
+
+    if argsString.match(/^[\{\[].+[\]\}]$/)
+      # destructuring assignment
+      argsString = argsString.replace(/([\{\}])/g, '\\$1')
+      args = ["${#{snippetCount++}:#{argsString}}"]
+    else if argsString.length > 0
+      args = argsString.split(',').map((arg) ->
+        [arg] = arg.split('=', 1)
+        "${#{snippetCount++}:#{arg.trim()}}"
+      )
+
+    "#{tag.name}(#{args.join(', ')})${#{snippetCount}}"


### PR DESCRIPTION
It's a copy of the existing Coffescript one, since the function syntax and tags are equivalent in Matlab.

It's my first GitHub pull request ever, so any pointers are welcome.
Also notice that I practically don't know any Coffescript at all (!).

There is a small issue, but I don't know if it's caused by this snipper of by the snipping system itself: if the opened files already have a reference to a function (that exists in the ctags file) it will be shown twice on the autocomplete list: once with the parameters (generated by the snipper) and another time without them (what the autocomplete-plus package generates when autocomplete-ctags isn't present). 

![captura de pantalla de 2015-07-01 00-59-42](https://cloud.githubusercontent.com/assets/962049/8447289/8fcb9130-1f8c-11e5-980b-7947b103bd2f.png)

When the snipping system is disabled in options, there are no duplicate symbols.

![captura de pantalla de 2015-07-01 01-01-01](https://cloud.githubusercontent.com/assets/962049/8447300/ae723ac6-1f8c-11e5-89a2-d89865eea4b6.png)

If this is an independent error, I'll gladly open a separate GitHub issue for this. But since I never used the Coffescript snipper, I don't know if this is the case.
