### PR TITLE
Use 'tag' as default suggestion type

### DIFF
--- a/lib/ctags-provider.coffee
+++ b/lib/ctags-provider.coffee
@@ -8,6 +8,11 @@ class CtagsProvider
   @kinds = {
     f: 'function'
     v: 'variable'
+    c: 'class'
+    p: 'property'
+    t: 'type'
+    k: 'keyword'
+    m: 'method'
   }
 
   selector: '.source'

--- a/lib/ctags-provider.coffee
+++ b/lib/ctags-provider.coffee
@@ -66,7 +66,7 @@ class CtagsProvider
       ).map((tag) =>
         text: tag.name
         description: tag.pattern
-        type: @constructor.kinds[tag.kind] ? null
+        type: @constructor.kinds[tag.kind] ? 'tag'
         snippet: @snippers?.generate(tag)
       )
 


### PR DESCRIPTION
1. Use 'tag' as default suggestion type.
   
   Refer to [Provider API](https://github.com/atom/autocomplete-plus/wiki/Provider-API). 'tag' is a builtin type.
2.  Add a few types to @kinds (temporary solution)

> # 10
